### PR TITLE
Added Winner Firmware Handler

### DIFF
--- a/api/csharp/CloudAPI/GameStateManager.cs
+++ b/api/csharp/CloudAPI/GameStateManager.cs
@@ -663,7 +663,7 @@ namespace CloudApi
 
             if (String.IsNullOrEmpty(deviceId))
             {
-                var selectedIndex = GameStateManager.RandomNumberGenerator.Next(0, (gameState.ActiveDevices.Count - 1));
+                var selectedIndex = GameStateManager.RandomNumberGenerator.Next(0, gameState.ActiveDevices.Count);
                 deviceId = gameState.ActiveDevices.ElementAt(selectedIndex);
             }
 

--- a/firmware/src/buttonpong.ino
+++ b/firmware/src/buttonpong.ino
@@ -26,6 +26,7 @@ void setup() {
 
     Particle.function("startGame", startGame);
     Particle.function("ping", ping);
+	Particle.function("winner", winner);
 
     buttonEvents.onButtonClicked(buttonClickedHandler);
     buttonEvents.onAllButtonsClicked(allButtonsClickedHandler);
@@ -173,6 +174,18 @@ int ping(String timeout) {
     }
 
     return val;
+}
+
+int winner(String args) {
+    Serial.println("Received winner event!");
+    
+    // YOU WON!
+    gameState = STATE_GAME_OVER;
+ 
+    b.playSong(TONE_WINNER);
+    b.rainbow(10);
+    
+    return 1;
 }
 
 void buttonClickedHandler(int buttonNumber) {


### PR DESCRIPTION
There was an event already fired to the Particle API from the Azure function to signal the winning device but no function on the firmware to catch it.

We added a firmware function to light up and play a sound on the winning device.